### PR TITLE
Sort files to prevent "comm: file 2 is not in sorted order"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ fetch: conf/repos.conf
 
 fetch-all: conf/repos.conf
 	@rm -f build/conf/bblayers.conf
-	@while read p; do ./git-fetch-remote.sh $$p; done <${CONF}
+	@while read p; do ./git-fetch-remote.sh $$p; done <conf/repos.conf
 
 install:
 	@cd install && make prod && make recover

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bb ccgx clean conf fetch fetch-all install update-repos.conf sdk venus-image $(addsuffix bb-,$(MACHINES))
+.PHONY: build/conf/bblayers.conf bb ccgx clean conf fetch fetch-all install update-repos.conf sdk venus-image $(addsuffix bb-,$(MACHINES))
 
 CONFIG = danny
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ build/conf/bblayers.conf:
 	@echo >> build/conf/bblayers.conf
 	@echo 'BBLAYERS = " \' >> build/conf/bblayers.conf
 	@find . -wholename "*/conf/layer.conf" | sed -e 's,/conf/layer.conf,,g' -e 's,^./,,g' | sort > metas.found
-	@comm -1 -2 metas.found metas.whitelist | sed -e 's,$$, \\,g' -e "s,^,$$PWD/,g" >> build/conf/bblayers.conf
+	@sort metas.found > metas.found.sorted.tmp
+	@sort metas.whitelist > metas.whitelist.sorted.tmp
+	@comm -1 -2 metas.found.sorted.tmp metas.whitelist.sorted.tmp | sed -e 's,$$, \\,g' -e "s,^,$$PWD/,g" >> build/conf/bblayers.conf
+	@rm metas.found.sorted.tmp metas.whitelist.sorted.tmp
 	@echo '"' >> build/conf/bblayers.conf
 
 %-bb:

--- a/README
+++ b/README
@@ -48,6 +48,9 @@ make fetch
 # install host packages (Debian based)
 make prereq
 
+# Replace dash with bash (Ubuntu only)
+sudo dpkg-reconfigure dash
+
 # build all, this will take a while though... it builds for all MACHINES as found
 # in conf/machines.
 make venus-image

--- a/git-fetch-remote.sh
+++ b/git-fetch-remote.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-printf "\n--------------- $1 - $2 -------------"
+printf "\n--------------- $1 - $2 -------------\n"
 
 if [ $# -lt 4 ]; then
 	echo "$0 directory fetch-url push-url (upstream|-)"
@@ -15,13 +15,15 @@ git --git-dir=$1/.git remote set-url --push origin $3
 # optionally set an upstream repository
 if [ "$4" != "-" ]; then
 	git --git-dir=$1/.git remote add upstream $4
+	git --git-dir=$1/.git --work-tree=$1 fetch upstream
 fi
 
-# optionally set an upstream repository
+# optionally checkout a specific branch
 if [ "$5" != "-" ]; then
 	git --git-dir=$1/.git --work-tree=$1 checkout "$5"
 fi
 
+# optionally set a specific upstream branch
 if [ "$6" != "-" ]; then
 	git --git-dir=$1/.git --work-tree=$1 branch -u "$6"
 fi

--- a/metas.whitelist
+++ b/metas.whitelist
@@ -6,12 +6,12 @@ sources/meta-openembedded/meta-oe
 sources/meta-openembedded/meta-python
 sources/meta-openembedded/meta-webserver
 sources/meta-swupdate
+sources/meta-victronenergy-private
 sources/meta-victronenergy/meta-alternatives
 sources/meta-victronenergy/meta-backports
 sources/meta-victronenergy/meta-bsp
 sources/meta-victronenergy/meta-third-party
-sources/meta-victronenergy/meta-venus
 sources/meta-victronenergy/meta-ve-software
-sources/meta-victronenergy-private
+sources/meta-victronenergy/meta-venus
 sources/meta-yocto/meta-yocto-bsp
 sources/openembedded-core/meta


### PR DESCRIPTION
Related to #16 

The file `metas.whitelist` is not sorted according to my PC, resulting in the error `comm: file 2 is not in sorted order` during `make venus-image`.

This PR will sort the files before calling `comm` to fix this issue for everybody everywhere.

```
quinox@ltsp5258:/mnt/drive/venus ^2 $ make venus-image
ln -sfn configs/danny conf
comm: file 2 is not in sorted order
export MACHINE=bpp3 && . ./sources/openembedded-core/oe-init-build-env build && bitbake venus-image
```