### PR TITLE
Allow overriding DL_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ build/conf/bblayers.conf:
 	@comm -1 -2 metas.found metas.whitelist.sorted.tmp | sed -e 's,$$, \\,g' -e "s,^,$$PWD/,g" >> build/conf/bblayers.conf
 	@rm metas.whitelist.sorted.tmp
 	@echo '"' >> build/conf/bblayers.conf
+ifdef DL_DIR
+	@echo 'DL_DIR = "${DL_DIR}"' >> build/conf/bblayers.conf
+endif
 
 %-bb:
 	@export MACHINE=$(subst -bb,,$@) && bash --init-file sources/openembedded-core/oe-init-build-env

--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -34,7 +34,7 @@ MACHINE ?= "bpp3"
 #
 # The default is a downloads directory under TOPDIR which is the build directory.
 #
-DL_DIR = "${TOPDIR}/../../oe-downloads"
+DL_DIR ?= "${TOPDIR}/../../oe-downloads"
 
 #
 # Where to place shared-state files


### PR DESCRIPTION
I'd like to specify an absolute path for DL_DIR via an env-var so I can share the downloaded files between multiple runners (which is supposed according to [the documentation](http://www.yoctoproject.org/docs/1.5/ref-manual/ref-manual.html#var-DL_DIR) / [mailing list post](http://lists.openembedded.org/pipermail/openembedded-core/2012-February/056962.html))