### PR TITLE
Added Raspberrypi2 support, version 2.

### DIFF
--- a/configs/jethro/machines
+++ b/configs/jethro/machines
@@ -1,1 +1,1 @@
-MACHINES=beaglebone ccgxhf achilles
+MACHINES=beaglebone ccgxhf achilles raspberrypi2


### PR DESCRIPTION
This goes with [this request](https://github.com/victronenergy/meta-victronenergy/pull/3), minor change here, it only adds raspberrypi2 as another machine.