### PR TITLE
Speed up deployment by using a runner closer to the CI server

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,8 +93,8 @@ deploy:
     - ./ci-upload-artifacts-to-build-feeds.sh $CI_BUILD_REF_NAME
   stage: deploy
   tags:
-    - venus
-    - linux
+    - almere
+    - osx
 
 deploy_www:
   only:
@@ -104,5 +104,5 @@ deploy_www:
     - ./ci-upload-artifacts-to-www.sh
   stage: deploy
   tags:
-    - venus
-    - linux
+    - almere
+    - osx


### PR DESCRIPTION
This PR will try to to speed up the deployment by not copying big files over the internet back and forth.

The setup itself works fine, I've tested it this morning with a tiny artifact. I haven't been able to verify the actual speedup since the full build from `master` is currently failing.