### PR TITLE
do-ci-build.sh: fix mistake in echo combined with ()

### DIFF
--- a/do-ci-build.sh
+++ b/do-ci-build.sh
@@ -1,20 +1,20 @@
 #!/bin/sh
 
 if [ "$1" = "" ]; then
-	echo usage $0 branch
+	echo "usage $0 branch"
 	echo
-	echo Creates a branch in the venus repo with the configs adjusted
-	echo to the checkouted branches in ./sources. It then adds a commit
-	echo with these changes and pushes the branchs (hard!) to the git-
-	echo remote under the name builder. Typically the VE gitlab server,
-	echo since that is running CI.
+	echo "Creates a branch in the venus repo with the configs adjusted"
+	echo "to the checkouted branches in ./sources. It then adds a commit"
+	echo "with these changes and pushes the branches (hard!) to the git-"
+	echo "remote under the name builder. Typically the VE gitlab server,"
+	echo "since that is running CI."
 	echo
-	echo As an extra bonus it puts the commitlog of all the commits
-	echo which are not yet in their master in the commit-message.
+	echo "As an extra bonus it puts the commitlog of all the commits"
+	echo "which are not yet in their master in the commit-message."
 	echo
-	echo WARNING: it will push the created venus branch hard to the
-	echo builder!! Make sure you do not use the name of a branch you
-	echo care about...
+	echo "WARNING: it will push the created venus branch hard to the"
+	echo "builder!! Make sure you do not use the name of a branch you"
+	echo "care about..."
 	exit 1
 fi
 


### PR DESCRIPTION
./do-ci-build.sh: line 8: syntax error near unexpected token `('
./do-ci-build.sh: line 8: `	echo with these changes and pushes the branchs (hard!) to the git-'

(sorry)