### PR TITLE
fix: various bug fixes across scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ build-scarthgap-full:
     - ./ci-upload-artifacts-to-build-feeds.sh $CI_COMMIT_REF_NAME
     - ./ci-upload-artifacts-to-www.sh
     # trigger a pipeline on venus-tests repo; master branch; and pass our branch in the BRANCH variable
-    - "curl -X POST -F token=56bd8d45f917e9ff0ff396005a8c98 -F ref=master -F variables[BRANCH]=$CI_COMMIT_REF_NAME \
+    - "curl -X POST -F token=$VENUS_TESTS_TRIGGER_TOKEN -F ref=master -F variables[BRANCH]=$CI_COMMIT_REF_NAME \
       -F variables[PUSH_TO_TESTING]=yes https://git.victronenergy.com/api/v4/projects/221/trigger/pipeline"
     - make clean
   stage: build
@@ -52,7 +52,7 @@ build-scarthgap:
     - ./ci-upload-artifacts-to-build-feeds.sh $CI_COMMIT_REF_NAME
     # trigger a pipeline on venus-tests repo; master branch; and pass our branch
     # in the BRANCH variable
-    - "curl -X POST -F token=56bd8d45f917e9ff0ff396005a8c98 -F ref=master \
+    - "curl -X POST -F token=$VENUS_TESTS_TRIGGER_TOKEN -F ref=master \
       -F variables[BRANCH]=$CI_COMMIT_REF_NAME https://git.victronenergy.com/api/v4/projects/221/trigger/pipeline"
   stage: build
   tags:

--- a/ci-populate-artifacts.sh
+++ b/ci-populate-artifacts.sh
@@ -137,7 +137,7 @@ function sdk
 # to convert existing products and for people expecting it there.
 function compat_symlinks
 {
-	mkdir $images/cerbosgx
+	mkdir -p $images/cerbosgx
 	for img in $(find -L "$images/einstein" -type f -printf "%f\n"); do
 		sgxname=$(echo "$img" | sed 's,-einstein,-cerbosgx,')
 		ln -sfr $images/einstein/$img $images/cerbosgx/$sgxname

--- a/do_release.sh
+++ b/do_release.sh
@@ -1,7 +1,6 @@
 DEPLOY=deploy/venus
 REMOTE=victron_www@updates-origin.victronenergy.com
 D=/var/www/victron_www/feeds/venus/
-FEED="$REMOTE:$OPKG"
 
 if [ $# -eq 0 ]; then
 	echo "Usage: $0 release|candidate|testing"

--- a/git-fetch-remote.sh
+++ b/git-fetch-remote.sh
@@ -47,14 +47,14 @@ fi
 # optionally checkout a branch
 if [ "$5" != "-" ]; then
 	git --git-dir=$1/.git --work-tree=$1 checkout "$5"
-fi
 
-# Set the checkout branch as default upstream branch
-#
-# Switching to OE point venus is based on can be done with:
-# ./repos branch -u 'origin/$upstream_branch'
-#
-git --git-dir=$1/.git --work-tree=$1 branch -u "origin/$5"
+	# Set the checkout branch as default upstream branch
+	#
+	# Switching to OE point venus is based on can be done with:
+	# ./repos branch -u 'origin/$upstream_branch'
+	#
+	git --git-dir=$1/.git --work-tree=$1 branch -u "origin/$5"
+fi
 
 echo "Set git config log.follow=true, to handle all the recipe renames"
 git --git-dir=$1/.git --work-tree=$1 config log.follow true

--- a/git-push-status.py
+++ b/git-push-status.py
@@ -28,7 +28,7 @@ if added_log != "":
 
 		if msg in removed.values():
 			rewritten[commit] = msg
-			del removed[removed.keys()[removed.values().index(msg)]]
+			del removed[list(removed.keys())[list(removed.values()).index(msg)]]
 		else:
 			added[commit] = msg
 

--- a/push-status.sh
+++ b/push-status.sh
@@ -1,3 +1,3 @@
-#/bin/sh
+#!/bin/sh
 
 ./repos_cmd $PWD/git-push-status.py

--- a/update-recipe.py
+++ b/update-recipe.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/python3
 
 import argparse
 import glob


### PR DESCRIPTION
- git-push-status.py: fix Python 3 incompatibility where dict.keys() and dict.values() return views that cannot be indexed; wrap with list()
- git-fetch-remote.sh: move 'git branch -u' inside the '$5 != -' conditional to avoid running 'git branch -u origin/-' when no branch is specified
- push-status.sh: fix missing '!' in shebang (#/bin/sh -> #!/bin/sh)
- update-recipe.py: fix shebang path (#!/bin/python3 -> #!/usr/bin/python3)
- do_release.sh: remove unused FEED variable that referenced undefined OPKG
- ci-populate-artifacts.sh: add -p flag to mkdir in compat_symlinks to avoid failure if parent dir is missing or directory already exists
- .gitlab-ci.yml: replace hardcoded pipeline trigger token with CI variable $VENUS_TESTS_TRIGGER_TOKEN to avoid exposing secrets in source control